### PR TITLE
fix SageMaker client output tokens

### DIFF
--- a/src/llmperf/ray_clients/sagemaker_client.py
+++ b/src/llmperf/ray_clients/sagemaker_client.py
@@ -101,7 +101,6 @@ class SageMakerClient(LLMClient):
 
             event_stream = response["Body"]
             json_byte = b""
-            generated_text = prompt
             start_json = b"{"
 
             for line, ttft, _ in LineIterator(event_stream):


### PR DESCRIPTION
Other clients include only the model output in `generated_text`, but the SageMaker client includes the prompt.
As a result, the output token rates are inflated by a factor of 3-4.
